### PR TITLE
Application autostart and extensions

### DIFF
--- a/src/NomadIIS/Services/Configuration/DriverTaskConfig.cs
+++ b/src/NomadIIS/Services/Configuration/DriverTaskConfig.cs
@@ -64,7 +64,7 @@ public sealed class DriverTaskConfig
 	#endregion
 }
 
-public sealed class DriverTaskConfigApplicationPool
+public sealed class DriverTaskConfigApplicationPool : DriverTaskConfigExtendable
 {
 	[ConfigurationField( "name" )]
 	[DefaultValue( IisTaskHandle.DefaultAppPoolName )]
@@ -104,7 +104,7 @@ public sealed class DriverTaskConfigApplicationPool
 	public TimeSpan? ShutdownTimeLimit { get; set; }
 }
 
-public sealed class DriverTaskConfigApplication
+public sealed class DriverTaskConfigApplication : DriverTaskConfigExtendable
 {
 	[ConfigurationField( "application_pool" )]
 	[DefaultValue( IisTaskHandle.DefaultAppPoolName )]
@@ -120,11 +120,17 @@ public sealed class DriverTaskConfigApplication
 	[ConfigurationField( "enable_preload" )]
 	public bool? EnablePreload { get; set; }
 
+	[ConfigurationField( "service_auto_start_enabled" )]
+	public bool? ServiceAutoStartEnabled { get; set; }
+
+	[ConfigurationField( "service_auto_start_provider" )]
+	public string? ServiceAutoStartProvider { get; set; }
+
 	[ConfigurationCollectionField( "virtual_directories", "virtual_directory" )]
 	public DriverTaskConfigVirtualDirectory[]? VirtualDirectories { get; set; }
 }
 
-public sealed class DriverTaskConfigVirtualDirectory
+public sealed class DriverTaskConfigVirtualDirectory : DriverTaskConfigExtendable
 {
 	[Required]
 	[ConfigurationField( "alias" )]
@@ -181,4 +187,21 @@ public enum DriverTaskConfigBindingType
 {
 	Http,
 	Https
+}
+
+public sealed class DriverTaskConfigExtension
+{
+	[Required]
+	[ConfigurationField( "key" )]
+	public string Key { get; set; } = default!;
+
+	[Required]
+	[ConfigurationField( "value" )]
+	public string Value { get; set; } = default!;
+}
+
+public abstract class DriverTaskConfigExtendable
+{
+	[ConfigurationCollectionField( "extensions", "extension" )]
+	public DriverTaskConfigExtension[]? Extensions { get; set; }
 }

--- a/src/NomadIIS/Services/Configuration/DriverTaskConfig.cs
+++ b/src/NomadIIS/Services/Configuration/DriverTaskConfig.cs
@@ -192,8 +192,8 @@ public enum DriverTaskConfigBindingType
 public sealed class DriverTaskConfigExtension
 {
 	[Required]
-	[ConfigurationField( "key" )]
-	public string Key { get; set; } = default!;
+	[ConfigurationField( "name" )]
+	public string Name { get; set; } = default!;
 
 	[Required]
 	[ConfigurationField( "value" )]

--- a/src/NomadIIS/Services/IisTaskHandle.cs
+++ b/src/NomadIIS/Services/IisTaskHandle.cs
@@ -677,12 +677,14 @@ public sealed class IisTaskHandle : IDisposable
 
 	private static void AddExtensions( ConfigurationElement configurationElement, DriverTaskConfigExtendable taskConfig)
 	{
-		if ( taskConfig.Extensions is not null )
+		if ( taskConfig.Extensions is null )
 		{
-			foreach ( var extension in taskConfig.Extensions )
-			{
-				configurationElement.SetAttributeValue(extension.Name, extension.Value);
-			}
+			return;
+		}
+
+		foreach ( var extension in taskConfig.Extensions )
+		{
+			configurationElement.SetAttributeValue(extension.Name, extension.Value);
 		}
 	}
 

--- a/src/NomadIIS/Services/IisTaskHandle.cs
+++ b/src/NomadIIS/Services/IisTaskHandle.cs
@@ -675,7 +675,7 @@ public sealed class IisTaskHandle : IDisposable
 		}
 	}
 
-	private static void AddExtensions( ConfigurationElement configurationElement, DriverTaskConfigExtendable taskConfig)
+	private static void AddExtensions( ConfigurationElement configurationElement, DriverTaskConfigExtendable taskConfig )
 	{
 		if ( taskConfig.Extensions is null )
 		{

--- a/src/NomadIIS/Services/IisTaskHandle.cs
+++ b/src/NomadIIS/Services/IisTaskHandle.cs
@@ -681,7 +681,7 @@ public sealed class IisTaskHandle : IDisposable
 		{
 			foreach ( var extension in taskConfig.Extensions )
 			{
-				configurationElement.SetAttributeValue(extension.Key, extension.Value);
+				configurationElement.SetAttributeValue(extension.Name, extension.Value);
 			}
 		}
 	}

--- a/website/docs/getting-started/task-configuration.md
+++ b/website/docs/getting-started/task-configuration.md
@@ -90,7 +90,7 @@ config {
 ## `extension` Block
 
 :::info
-In the event that a configurable property is not supported, an extension may be used.  Extensions will overwrite any existing configured property.
+In the event that a configurable property is not supported by a block type, an extension may be used.  Each extension will set a corresponding attribute via the [IIS setting schema](https://learn.microsoft.com/en-us/previous-versions/iis/settings-schema/aa347559(v=vs.90)).  Using an unsupported attribute may cause IIS failures.
 
 | Option | Type | Required | Default Value | Description |
 |---|---|---|---|---|

--- a/website/docs/getting-started/task-configuration.md
+++ b/website/docs/getting-started/task-configuration.md
@@ -64,6 +64,7 @@ config {
 | queue_length | number | no | *IIS default* | Indicates to HTTP.sys how many requests to queue for an application pool before rejecting future requests. |
 | start_time_limit | string | no | *IIS default* | Specifies the time in the form *[00w][00d][00h][00m][00s]* that IIS waits for an application pool to start. If the application pool does not startup within the startupTimeLimit, the worker process is terminated and the rapid-fail protection count is incremented. |
 | shutdown_time_limit | string | no | *IIS default* | Specifies the time in the form *[00w][00d][00h][00m][00s]* that the W3SVC service waits after it initiated a recycle. If the worker process does not shut down within the shutdownTimeLimit, it will be terminated by the W3SVC service. |
+| *extension* | block list | no | *none* | Allows for additional attributes for properties not explicitly supported. See *extension* schema below for details. |
 
 ## `application` Block
 
@@ -73,7 +74,10 @@ config {
 | alias | string | no | `/` | Defines an optional alias at which the application should be hosted below the website. If not set, the application will be hosted at the website level. |
 | application_pool | string | no | `default` | References an application pool on which this application should be executed. |
 | enable_preload | bool | no | *IIS default* | Specifies whether the application should be pre-loaded. |
+| service_auto_start_enabled | bool | no | *IIS default* | Specifies whether the application should be automatically started. |
+| service_auto_start_provider | string | no | *IIS default* | Specifies the name of the autostart provider if service_auto_start_enabled is set to true. |
 | *virtual_directory* | block list | no | *none* | Defines optional virtual directories below this application. See *virtual_directory* schema below for details. |
+| *extension* | block list | no | *none* | Allows for additional attributes for properties not explicitly supported. See *extension* schema below for details. |
 
 ## `virtual_directory` Block
 
@@ -81,6 +85,17 @@ config {
 |---|---|---|---|---|
 | alias | string | yes | *none* | Defines the alias of the virtual directory |
 | path | string | yes | *none* | Defines the path of the virtual directory |
+| *extension* | block list | no | *none* | Allows for additional attributes for properties not explicitly supported. See *extension* schema below for details. |
+
+## `extension` Block
+
+:::info
+In the event that a configurable property is not supported, an extension may be used.  Extensions will overwrite any existing configured property.
+
+| Option | Type | Required | Default Value | Description |
+|---|---|---|---|---|
+| key | string | yes | *none* | Defines the extension key |
+| value | string | yes | *none* | Defines the extension value |
 
 ## `binding` Block
 

--- a/website/docs/getting-started/task-configuration.md
+++ b/website/docs/getting-started/task-configuration.md
@@ -4,25 +4,25 @@ sidebar_position: 5
 
 # Task Configuration
 
-| Option | Type | Required | Default Value | Description |
-|---|---|---|---|---|
-| *applicationPool* | block list | no | *none* | Defines one more application pools. See *applicationPool* schema below for details. |
-| *application* | block list | yes | *none* | Defines one more applications. See *application* schema below for details. |
-| target_website | string | no | *none* | Specifies an existing target website. In this case the driver will not create a new website but instead use the existing one where it provisions the virtual applications only. Please read the details [here](../features/existing-website.md). |
-| enable_udp_logging | bool | no | false | Enables a UDP log-sink your application can log to. Please read the details [here](../features/udp-logging.md). |
-| permit_iusr | bool | no | true | Specifies whether you want to permit the [IUSR-account](https://learn.microsoft.com/en-us/iis/get-started/planning-for-security/understanding-built-in-user-and-group-accounts-in-iis#understanding-the-new-iusr-account) on the *local* directory. When you disable this, you may need to tweak your *web.config* a bit. Read [this](./faq.md#iusr-account) for details. |
-| *binding* | block list | yes | *none* | Defines one or two port bindings. See *binding* schema below for details. |
-| ~~managed_pipeline_mode~~ | string | no | *IIS default* | Valid options are *Integrated* or *Classic* |
-| ~~enable_32bit_app_on_win64~~ | bool | no | *IIS default* | When true, enables a 32-bit application to run on a computer that runs a 64-bit version of Windows. |
-| ~~managed_runtime_version~~ | string | no | *IIS default* | Valid options are *v4.0*, *v2.0*, *None* |
-| ~~start_mode~~ | string | no | *IIS default* | Valid options are *OnDemand* or *AlwaysRunning* |
-| ~~idle_timeout~~ | string | no | *IIS default* | The AppPool idle timeout in the form *HH:mm:ss* or *[00w][00d][00h][00m][00s]* |
-| ~~disable_overlapped_recycle~~ | bool | no | *IIS default* | Defines whether two AppPools are allowed to run while recycling |
-| ~~periodic_restart~~ | string | no | *IIS default* | The AppPool periodic restart interval in the form *HH:mm:ss* or *[00w][00d][00h][00m][00s]* |
-| ~~service_unavailable_response~~ | string | no | *IIS default* | If this is set to `HttpLevel` and the app pool isn't running, HTTP.sys will return a 503 http-error. On the other hand if this is set to `TcpLevel` and the app pool isn't running, HTTP.sys will simply drop the connection. This may be useful when using external load balancers. |
-| ~~queue_length~~ | number | no | *IIS default* | Indicates to HTTP.sys how many requests to queue for an application pool before rejecting future requests. |
-| ~~start_time_limit~~ | string | no | *IIS default* | Specifies the time in the form *[00w][00d][00h][00m][00s]* that IIS waits for an application pool to start. If the application pool does not startup within the startupTimeLimit, the worker process is terminated and the rapid-fail protection count is incremented. |
-| ~~shutdown_time_limit~~ | string | no | *IIS default* | Specifies the time in the form *[00w][00d][00h][00m][00s]* that the W3SVC service waits after it initiated a recycle. If the worker process does not shut down within the shutdownTimeLimit, it will be terminated by the W3SVC service. |
+| Option                           | Type       | Required | Default Value | Description                                                                                                                                                                                                                                                                                                                                                               |
+| -------------------------------- | ---------- | -------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| _applicationPool_                | block list | no       | _none_        | Defines one more application pools. See _applicationPool_ schema below for details.                                                                                                                                                                                                                                                                                       |
+| _application_                    | block list | yes      | _none_        | Defines one more applications. See _application_ schema below for details.                                                                                                                                                                                                                                                                                                |
+| target_website                   | string     | no       | _none_        | Specifies an existing target website. In this case the driver will not create a new website but instead use the existing one where it provisions the virtual applications only. Please read the details [here](../features/existing-website.md).                                                                                                                          |
+| enable_udp_logging               | bool       | no       | false         | Enables a UDP log-sink your application can log to. Please read the details [here](../features/udp-logging.md).                                                                                                                                                                                                                                                           |
+| permit_iusr                      | bool       | no       | true          | Specifies whether you want to permit the [IUSR-account](https://learn.microsoft.com/en-us/iis/get-started/planning-for-security/understanding-built-in-user-and-group-accounts-in-iis#understanding-the-new-iusr-account) on the _local_ directory. When you disable this, you may need to tweak your _web.config_ a bit. Read [this](./faq.md#iusr-account) for details. |
+| _binding_                        | block list | yes      | _none_        | Defines one or two port bindings. See _binding_ schema below for details.                                                                                                                                                                                                                                                                                                 |
+| ~~managed_pipeline_mode~~        | string     | no       | _IIS default_ | Valid options are _Integrated_ or _Classic_                                                                                                                                                                                                                                                                                                                               |
+| ~~enable_32bit_app_on_win64~~    | bool       | no       | _IIS default_ | When true, enables a 32-bit application to run on a computer that runs a 64-bit version of Windows.                                                                                                                                                                                                                                                                       |
+| ~~managed_runtime_version~~      | string     | no       | _IIS default_ | Valid options are _v4.0_, _v2.0_, _None_                                                                                                                                                                                                                                                                                                                                  |
+| ~~start_mode~~                   | string     | no       | _IIS default_ | Valid options are _OnDemand_ or _AlwaysRunning_                                                                                                                                                                                                                                                                                                                           |
+| ~~idle_timeout~~                 | string     | no       | _IIS default_ | The AppPool idle timeout in the form _HH:mm:ss_ or _[00w][00d][00h][00m][00s]_                                                                                                                                                                                                                                                                                            |
+| ~~disable_overlapped_recycle~~   | bool       | no       | _IIS default_ | Defines whether two AppPools are allowed to run while recycling                                                                                                                                                                                                                                                                                                           |
+| ~~periodic_restart~~             | string     | no       | _IIS default_ | The AppPool periodic restart interval in the form _HH:mm:ss_ or _[00w][00d][00h][00m][00s]_                                                                                                                                                                                                                                                                               |
+| ~~service_unavailable_response~~ | string     | no       | _IIS default_ | If this is set to `HttpLevel` and the app pool isn't running, HTTP.sys will return a 503 http-error. On the other hand if this is set to `TcpLevel` and the app pool isn't running, HTTP.sys will simply drop the connection. This may be useful when using external load balancers.                                                                                      |
+| ~~queue_length~~                 | number     | no       | _IIS default_ | Indicates to HTTP.sys how many requests to queue for an application pool before rejecting future requests.                                                                                                                                                                                                                                                                |
+| ~~start_time_limit~~             | string     | no       | _IIS default_ | Specifies the time in the form _[00w][00d][00h][00m][00s]_ that IIS waits for an application pool to start. If the application pool does not startup within the startupTimeLimit, the worker process is terminated and the rapid-fail protection count is incremented.                                                                                                    |
+| ~~shutdown_time_limit~~          | string     | no       | _IIS default_ | Specifies the time in the form _[00w][00d][00h][00m][00s]_ that the W3SVC service waits after it initiated a recycle. If the worker process does not shut down within the shutdownTimeLimit, it will be terminated by the W3SVC service.                                                                                                                                  |
 
 :::note
 Strikethrough configuration options will be removed in the next version. Please use the [`applicationPool` block](#applicationpool-block) instead.
@@ -50,63 +50,63 @@ config {
 </details>
 :::
 
-| Option | Type | Required | Default Value | Description |
-|---|---|---|---|---|
-| name | string | no | `default` | Specifies an alias name for the application pool. This can be used to reference the application pool within the `application` block. It is limited to 8 characters. |
-| managed_pipeline_mode | string | no | *IIS default* | Valid options are *Integrated* or *Classic* |
-| enable_32bit_app_on_win64 | bool | no | *IIS default* | When true, enables a 32-bit application to run on a computer that runs a 64-bit version of Windows. |
-| managed_runtime_version | string | no | *IIS default* | Valid options are *v4.0*, *v2.0*, *None* |
-| start_mode | string | no | *IIS default* | Valid options are *OnDemand* or *AlwaysRunning* |
-| idle_timeout | string | no | *IIS default* | The AppPool idle timeout in the form *HH:mm:ss* or *[00w][00d][00h][00m][00s]* |
-| disable_overlapped_recycle | bool | no | *IIS default* | Defines whether two AppPools are allowed to run while recycling |
-| periodic_restart | string | no | *IIS default* | The AppPool periodic restart interval in the form *HH:mm:ss* or *[00w][00d][00h][00m][00s]* |
-| service_unavailable_response | string | no | *IIS default* | If this is set to `HttpLevel` and the app pool isn't running, HTTP.sys will return a 503 http-error. On the other hand if this is set to `TcpLevel` and the app pool isn't running, HTTP.sys will simply drop the connection. This may be useful when using external load balancers. |
-| queue_length | number | no | *IIS default* | Indicates to HTTP.sys how many requests to queue for an application pool before rejecting future requests. |
-| start_time_limit | string | no | *IIS default* | Specifies the time in the form *[00w][00d][00h][00m][00s]* that IIS waits for an application pool to start. If the application pool does not startup within the startupTimeLimit, the worker process is terminated and the rapid-fail protection count is incremented. |
-| shutdown_time_limit | string | no | *IIS default* | Specifies the time in the form *[00w][00d][00h][00m][00s]* that the W3SVC service waits after it initiated a recycle. If the worker process does not shut down within the shutdownTimeLimit, it will be terminated by the W3SVC service. |
-| *extension* | block list | no | *none* | Allows for additional attributes for properties not explicitly supported. See *extension* schema below for details. |
+| Option                       | Type       | Required | Default Value | Description                                                                                                                                                                                                                                                                          |
+| ---------------------------- | ---------- | -------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| name                         | string     | no       | `default`     | Specifies an alias name for the application pool. This can be used to reference the application pool within the `application` block. It is limited to 8 characters.                                                                                                                  |
+| managed_pipeline_mode        | string     | no       | _IIS default_ | Valid options are _Integrated_ or _Classic_                                                                                                                                                                                                                                          |
+| enable_32bit_app_on_win64    | bool       | no       | _IIS default_ | When true, enables a 32-bit application to run on a computer that runs a 64-bit version of Windows.                                                                                                                                                                                  |
+| managed_runtime_version      | string     | no       | _IIS default_ | Valid options are _v4.0_, _v2.0_, _None_                                                                                                                                                                                                                                             |
+| start_mode                   | string     | no       | _IIS default_ | Valid options are _OnDemand_ or _AlwaysRunning_                                                                                                                                                                                                                                      |
+| idle_timeout                 | string     | no       | _IIS default_ | The AppPool idle timeout in the form _HH:mm:ss_ or _[00w][00d][00h][00m][00s]_                                                                                                                                                                                                       |
+| disable_overlapped_recycle   | bool       | no       | _IIS default_ | Defines whether two AppPools are allowed to run while recycling                                                                                                                                                                                                                      |
+| periodic_restart             | string     | no       | _IIS default_ | The AppPool periodic restart interval in the form _HH:mm:ss_ or _[00w][00d][00h][00m][00s]_                                                                                                                                                                                          |
+| service_unavailable_response | string     | no       | _IIS default_ | If this is set to `HttpLevel` and the app pool isn't running, HTTP.sys will return a 503 http-error. On the other hand if this is set to `TcpLevel` and the app pool isn't running, HTTP.sys will simply drop the connection. This may be useful when using external load balancers. |
+| queue_length                 | number     | no       | _IIS default_ | Indicates to HTTP.sys how many requests to queue for an application pool before rejecting future requests.                                                                                                                                                                           |
+| start_time_limit             | string     | no       | _IIS default_ | Specifies the time in the form _[00w][00d][00h][00m][00s]_ that IIS waits for an application pool to start. If the application pool does not startup within the startupTimeLimit, the worker process is terminated and the rapid-fail protection count is incremented.               |
+| shutdown_time_limit          | string     | no       | _IIS default_ | Specifies the time in the form _[00w][00d][00h][00m][00s]_ that the W3SVC service waits after it initiated a recycle. If the worker process does not shut down within the shutdownTimeLimit, it will be terminated by the W3SVC service.                                             |
+| _extension_                  | block list | no       | _none_        | Allows for additional attributes for properties not explicitly supported. See _extension_ schema below for details.                                                                                                                                                                  |
 
 ## `application` Block
 
-| Option | Type | Required | Default Value | Description |
-|---|---|---|---|---|
-| path | string | yes | *none* | Defines the path of the web application, containing the application files. If this folder is empty, the [Placeholder App](../getting-started/driver-configuration.md) will be copied into. |
-| alias | string | no | `/` | Defines an optional alias at which the application should be hosted below the website. If not set, the application will be hosted at the website level. |
-| application_pool | string | no | `default` | References an application pool on which this application should be executed. |
-| enable_preload | bool | no | *IIS default* | Specifies whether the application should be pre-loaded. |
-| service_auto_start_enabled | bool | no | *IIS default* | Specifies whether the application should be automatically started. |
-| service_auto_start_provider | string | no | *IIS default* | Specifies the name of the autostart provider if service_auto_start_enabled is set to true. |
-| *virtual_directory* | block list | no | *none* | Defines optional virtual directories below this application. See *virtual_directory* schema below for details. |
-| *extension* | block list | no | *none* | Allows for additional attributes for properties not explicitly supported. See *extension* schema below for details. |
+| Option                      | Type       | Required | Default Value | Description                                                                                                                                                                                |
+| --------------------------- | ---------- | -------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| path                        | string     | yes      | _none_        | Defines the path of the web application, containing the application files. If this folder is empty, the [Placeholder App](../getting-started/driver-configuration.md) will be copied into. |
+| alias                       | string     | no       | `/`           | Defines an optional alias at which the application should be hosted below the website. If not set, the application will be hosted at the website level.                                    |
+| application_pool            | string     | no       | `default`     | References an application pool on which this application should be executed.                                                                                                               |
+| enable_preload              | bool       | no       | _IIS default_ | Specifies whether the application should be pre-loaded.                                                                                                                                    |
+| service_auto_start_enabled  | bool       | no       | _IIS default_ | Specifies whether the application should be automatically started.                                                                                                                         |
+| service_auto_start_provider | string     | no       | _IIS default_ | Specifies the name of the autostart provider if service_auto_start_enabled is set to true.                                                                                                 |
+| _virtual_directory_         | block list | no       | _none_        | Defines optional virtual directories below this application. See _virtual_directory_ schema below for details.                                                                             |
+| _extension_                 | block list | no       | _none_        | Allows for additional attributes for properties not explicitly supported. See _extension_ schema below for details.                                                                        |
 
 ## `virtual_directory` Block
 
-| Option | Type | Required | Default Value | Description |
-|---|---|---|---|---|
-| alias | string | yes | *none* | Defines the alias of the virtual directory |
-| path | string | yes | *none* | Defines the path of the virtual directory |
-| *extension* | block list | no | *none* | Allows for additional attributes for properties not explicitly supported. See *extension* schema below for details. |
+| Option      | Type       | Required | Default Value | Description                                                                                                         |
+| ----------- | ---------- | -------- | ------------- | ------------------------------------------------------------------------------------------------------------------- |
+| alias       | string     | yes      | _none_        | Defines the alias of the virtual directory                                                                          |
+| path        | string     | yes      | _none_        | Defines the path of the virtual directory                                                                           |
+| _extension_ | block list | no       | _none_        | Allows for additional attributes for properties not explicitly supported. See _extension_ schema below for details. |
 
 ## `extension` Block
 
 :::info
-In the event that a configurable property is not supported by a block type, an extension may be used.  Each extension will set a corresponding attribute via the [IIS setting schema](https://learn.microsoft.com/en-us/previous-versions/iis/settings-schema/aa347559(v=vs.90)).  Using an unsupported attribute may cause IIS failures.
+In the event that a configurable property is not supported by a block type, an extension may be used. Each extension will set a corresponding attribute via the [IIS setting schema](<https://learn.microsoft.com/en-us/previous-versions/iis/settings-schema/aa347559(v=vs.90)>). Using an unsupported attribute may cause IIS failures.
 
-| Option | Type | Required | Default Value | Description |
-|---|---|---|---|---|
-| key | string | yes | *none* | Defines the extension key |
-| value | string | yes | *none* | Defines the extension value |
+| Option | Type   | Required | Default Value | Description                 |
+| ------ | ------ | -------- | ------------- | --------------------------- |
+| name   | string | yes      | _none_        | Defines the attribute name  |
+| value  | string | yes      | _none_        | Defines the attribute value |
 
 ## `binding` Block
 
-| Option | Type | Required | Default Value | Description |
-|---|---|---|---|---|
-| type | string | yes | *none* | Defines the protocol of the port binding. Allowed values are *http* or *https*. |
-| port | string | yes | *none* | Defines the port label of a `network` block or a static port like "80". Static ports can only be used when *hostname* is also set. Otherwise use a nomad *network*-stanza to specify the port. |
-| hostname | string | no | *IIS default* | Only listens to the specified hostname |
-| require_sni | bool | no | *IIS default* | Defines whether SNI (Server Name Indication) is required |
-| ip_address | string | no | *IIS default* | Specifies the IP-Address of the interface to listen on |
-| *certificate* | block list | no | *none* | Specifies the certificate to use when using type=https. See *certificate* schema below for details. |
+| Option        | Type       | Required | Default Value | Description                                                                                                                                                                                    |
+| ------------- | ---------- | -------- | ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| type          | string     | yes      | _none_        | Defines the protocol of the port binding. Allowed values are _http_ or _https_.                                                                                                                |
+| port          | string     | yes      | _none_        | Defines the port label of a `network` block or a static port like "80". Static ports can only be used when _hostname_ is also set. Otherwise use a nomad _network_-stanza to specify the port. |
+| hostname      | string     | no       | _IIS default_ | Only listens to the specified hostname                                                                                                                                                         |
+| require_sni   | bool       | no       | _IIS default_ | Defines whether SNI (Server Name Indication) is required                                                                                                                                       |
+| ip_address    | string     | no       | _IIS default_ | Specifies the IP-Address of the interface to listen on                                                                                                                                         |
+| _certificate_ | block list | no       | _none_        | Specifies the certificate to use when using type=https. See _certificate_ schema below for details.                                                                                            |
 
 ## `certificate` Block
 
@@ -114,14 +114,14 @@ In the event that a configurable property is not supported by a block type, an e
 Also refer to this [advanced documentation](../features/https.md).
 :::
 
-| Option | Type | Required | Default Value | Description |
-|---|---|---|---|---|
-| thumbprint | string | no | *none* | Specifies the thumbprint (hash) of a local and pre-installed certificate. Make sure the certificate is accessible to IIS by installing it to the *My Certificates* store on Local Machine. |
-| pfx_file | string | no | *none* | Specifies the path to a local certificate file. The file must be of type *.pfx*. |
-| password | string | no | *none* | Specifies the password for the given pfx-certificate file. |
-| cert_file | string | no | *none* | Specifies the path to a local certificate file in base64-encoded pem format. When using this option you also need to specify `key_file`. |
-| key_file | string | no | *none* | Specifies the path to a local private key file in base64-encoded pkcs8 format. When using this option you also need to specify `cert_file`. |
-| use_self_signed | bool | no | false | Set this to true if you want to use a self-signed certificate with a validity of one year. Important: This is not intended for production usage and should only be used for short lived tasks like UI- or Integration tests. |
+| Option          | Type   | Required | Default Value | Description                                                                                                                                                                                                                  |
+| --------------- | ------ | -------- | ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| thumbprint      | string | no       | _none_        | Specifies the thumbprint (hash) of a local and pre-installed certificate. Make sure the certificate is accessible to IIS by installing it to the _My Certificates_ store on Local Machine.                                   |
+| pfx_file        | string | no       | _none_        | Specifies the path to a local certificate file. The file must be of type _.pfx_.                                                                                                                                             |
+| password        | string | no       | _none_        | Specifies the password for the given pfx-certificate file.                                                                                                                                                                   |
+| cert_file       | string | no       | _none_        | Specifies the path to a local certificate file in base64-encoded pem format. When using this option you also need to specify `key_file`.                                                                                     |
+| key_file        | string | no       | _none_        | Specifies the path to a local private key file in base64-encoded pkcs8 format. When using this option you also need to specify `cert_file`.                                                                                  |
+| use_self_signed | bool   | no       | false         | Set this to true if you want to use a self-signed certificate with a validity of one year. Important: This is not intended for production usage and should only be used for short lived tasks like UI- or Integration tests. |
 
 ## Example
 
@@ -142,7 +142,7 @@ job "static-sample-app" {
     # disconnect {
     #  lost_after = "1m"
     # }
-  
+
     network {
       port "httplabel" {}
     }
@@ -159,13 +159,13 @@ job "static-sample-app" {
         application {
           path = "local"
         }
-    
+
         binding {
           type = "http"
           port = "httplabel"
         }
       }
-    
+
       resources {
         cpu    = 100
         memory = 20


### PR DESCRIPTION
This PR adds support for application properties service_auto_start_enabled and service_auto_start_provider ([overview docs](https://learn.microsoft.com/en-us/iis/configuration/system.applicationhost/serviceautostartproviders/)).   

On IIS the application's service_auto_start_provider is used in conjunction with a separate `<serviceAutoStartProviders>` root entity.  I've opted to leave out of scope for this PR.  The idea is that the list of providers would be configured separately and prior to a nomad allocation.

I've also added a new configurable "extension" block.  This provides a map of "extension" properties for applications, app pools, and virtual directories to allow additional IIS properties to be set on these types that aren't explicitly supported by the driver configuration model.  I've opted not to add any validation around this feature, but have included a warning/disclaimer in the docs.

Example
```
applicationPool {
  extension {
    name = "passAnonymousToken"
    value = "false"
  }
}
```