### PR TITLE
Updating binding limit to 64 to match IIS site limit

### DIFF
--- a/src/NomadIIS/Services/Configuration/DriverTaskConfig.cs
+++ b/src/NomadIIS/Services/Configuration/DriverTaskConfig.cs
@@ -20,7 +20,7 @@ public sealed class DriverTaskConfig
 	[ConfigurationField( "permit_iusr" )]
 	public bool PermitIusr { get; set; } = true;
 
-	[ConfigurationCollectionField( "bindings", "binding", 0, 2 )]
+	[ConfigurationCollectionField( "bindings", "binding", 0, 64 )]
 	public DriverTaskConfigBinding[] Bindings { get; set; } = default!;
 }
 

--- a/src/NomadIIS/Services/ManagementService.cs
+++ b/src/NomadIIS/Services/ManagementService.cs
@@ -53,7 +53,7 @@ public sealed class ManagementService : IHostedService
 	public string? ProcdumpBinaryPath => _procdumpConfig?.BinaryPath ?? "C:\\procdump.exe";
 	public bool ProcdumpEulaAccepted => _procdumpConfig?.AcceptEula ?? false;
 
-	public async void Configure ( DriverConfig config )
+	public Task Configure ( DriverConfig config )
 	{
 		_driverEnabled = config.Enabled;
 
@@ -65,6 +65,8 @@ public sealed class ManagementService : IHostedService
 		_allowedTargetWebsites = config.AllowedTargetWebsites ?? Array.Empty<string>();
 		_placeholderAppPath = config.PlaceholderAppPath;
 		_procdumpConfig = config.Procdumps.Length == 1 ? config.Procdumps[0] : null;
+
+		return Task.CompletedTask;
 	}
 
 	public Task StartAsync ( CancellationToken cancellationToken )
@@ -74,12 +76,14 @@ public sealed class ManagementService : IHostedService
 
 		return Task.CompletedTask;
 	}
-	public async Task StopAsync ( CancellationToken cancellationToken )
+	public Task StopAsync ( CancellationToken cancellationToken )
 	{
 		_cts.Cancel();
 
 		_wmiHelper.Dispose();
 		_serverManager.Dispose();
+
+		return Task.CompletedTask;
 	}
 
 	public IisTaskHandle CreateHandle ( string taskId )


### PR DESCRIPTION
resolves #138 

- update binding limit to [match IIS](https://techcommunity.microsoft.com/blog/iis-support-blog/iis-binding-limit-401-2-error/1006370)
- clean up two warnings for non-await async methods



